### PR TITLE
`RealIP()`: Fix handling `X-Forwarded-For` header

### DIFF
--- a/mware/realip.go
+++ b/mware/realip.go
@@ -22,12 +22,13 @@ func RealIP(never ...string) func(http.Handler) http.Handler {
 }
 
 func realIP(r *http.Request) string {
-	cfip := r.Header.Get("Cf-Connecting-Ip")
+
+	cfip := r.Header.Get("CF-Connecting-IP")
 	if cfip != "" && !znet.PrivateIPString(cfip) {
 		return cfip
 	}
 
-	xrip := r.Header.Get("X-Real-Ip")
+	xrip := r.Header.Get("X-Real-IP")
 	if xrip != "" && !znet.PrivateIPString(xrip) {
 		return xrip
 	}
@@ -35,7 +36,7 @@ func realIP(r *http.Request) string {
 	xff := r.Header.Get("X-Forwarded-For")
 	if xff != "" {
 		xffSplit := strings.Split(xff, ",")
-		for i := len(xffSplit) - 1; i >= 0; i-- {
+		for i := 0; i < len(xffSplit); i++ {
 			if !znet.PrivateIPString(xffSplit[i]) {
 				return strings.TrimSpace(xffSplit[i])
 			}

--- a/mware/realip_test.go
+++ b/mware/realip_test.go
@@ -27,6 +27,7 @@ func TestRealIP(t *testing.T) {
 		// X-Forwarded-For
 		{"1.1.1.1", http.Header{"X-Forwarded-For": {"101.100.100.100"}}, "101.100.100.100"},
 		{"4006:beef::0", http.Header{"X-Forwarded-For": {"4006:dead::0"}}, "4006:dead::0"},
+		{"1.1.1.1", http.Header{"X-Forwarded-For": {"2.2.2.2", "101.100.100.100"}}, "2.2.2.2"},
 
 		// Filter local
 		{"1.1.1.1", http.Header{"X-Real-Ip": {"192.168.5.5"}}, "1.1.1.1"},


### PR DESCRIPTION
You were looping over the IPs in `X-Forwarded-For` in the wrong direction, i.e. starting with the last instead of the first entry. [According to Wikipedia](https://en.wikipedia.org/wiki/X-Forwarded-For#Format), the client IP is the *first* entry, which is also what [Fly's documentation says](https://fly.io/docs/reference/runtime-environment/#x-forwarded-for).

### Notes

- I've also changed all the header names to their official form, which improves readability a bit IMHO. `Header.Get` is case-insensitive anyways since [`textproto.CanonicalMIMEHeaderKey` is used to canonicalize the provided key](https://pkg.go.dev/net/http#Header.Get).

- [Fly.io](https://fly.io/)'s HTTP proxy also sets the [`Fly-Client-IP`](https://fly.io/docs/reference/runtime-environment/#fly-client-ip) header in the same manner that Cloudflare sets `CF-Connecting-IP`. Adding support for `Fly-Client-IP` would also resolve my issue. ~~But since `X-Forwarded-For` is a [de-facto standard header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For), it should be preferred, I guess.~~ *This was a misconception, see addendum below.*

- There's also the [`Forwarded` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded) which seems to be the standardized unified equivalent to the `X-Forwarded-*` headers. Ideally, GoatCounter would also support that, I guess.

- I'm a complete beginner in Golang, so please bear with me. 😅

---

### Addendum

While investigating this whole "real IP story" a bit further, I've stumpled upon the research of @adam-p, i.e. [this comprehensive blog post](https://adam-p.ca/blog/2022/03/x-forwarded-for/) as well as his [realclientip-go](https://github.com/realclientip/realclientip-go) Go module. It appears, it's almost impossible to have a solution that works out-of-the-box for all possible environments/proxies. 😕

A few select quotes:

> If you’re doing something not obviously security-related… Think hard about your use case. Let’s say you just want to do an [IP-geolocation](https://en.wikipedia.org/wiki/Internet_geolocation) lookup for your stats. Probably the leftmost-ish IP is what you want. The vast majority of your users won’t be doing any header spoofing, and the geolocation of random internet proxies are no good to you, so you’ll probably get the best results with the IP closest to the user.

...

> Where you should be looking for the “real” client IP is very specific to your network architecture and use case. A default configuration encourages blind, naïve use and will result in incorrect and potentially dangerous behaviour more often than not.
>
> If you’re using Cloudflare you want `CF-Connecting-IP`. If you’re using `ngx_http_realip_module`, you want `X-Real-IP`. If you’re behind AWS ALB you want the rightmost-ish `X-Forwarded-For` IP. If you’re directly connected to the internet, you want `RemoteAddr` (or equivalent). And so on.
>
> There’s never a time when you’re okay with just falling back across a big list of header values that have nothing to do with your network architecture. That’s going to bite you.

See also https://github.com/golang/go/issues/51493, especially [this comment](https://github.com/golang/go/issues/51493#issuecomment-1059903172).

I think you can better judge what the best way forward is. Maybe we should introduce some additional config option(s), so GoatCounter users can tailor the "real" IP address determination to their environment?

If you'd like to keep the `X-Forwarded-For` header parsing the way it is, would you welcome a PR that [adds support for the `Fly-Client-IP` header](https://github.com/salim-b/zhttp/commit/4650e85f9e28afb349edb8d8db114b51a6427242) instead?