### PR TITLE
Add support for running under a path

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -34,7 +34,7 @@ func SetCookie(w http.ResponseWriter, val, domain string) {
 		Domain:   znet.RemovePort(domain),
 		Name:     cookieKey,
 		Value:    val,
-		Path:     "/",
+		Path:     zhttp.CookiePath(),
 		Expires:  time.Now().Add(oneYear),
 		HttpOnly: true,
 		Secure:   zhttp.CookieSecure,
@@ -52,7 +52,7 @@ func ClearCookie(w http.ResponseWriter, domain string) {
 		Domain:  znet.RemovePort(domain),
 		Name:    cookieKey,
 		Value:   "",
-		Path:    "/",
+		Path:    zhttp.CookiePath(),
 		Expires: time.Now().Add(-24 * time.Hour),
 	})
 }

--- a/flash.go
+++ b/flash.go
@@ -76,7 +76,7 @@ func ReadFlash(w http.ResponseWriter, r *http.Request) *FlashMessage {
 		return nil
 	}
 	http.SetCookie(w, &http.Cookie{
-		Name: cookieFlash, Value: "", Path: "/",
+		Name: cookieFlash, Value: "", Path: CookiePath(),
 		Expires: time.Now().Add(-24 * time.Hour),
 	})
 	return &FlashMessage{string(c.Value[0]), string(b)}
@@ -91,7 +91,7 @@ func flash(w http.ResponseWriter, lvl, msg string, v ...any) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     cookieFlash,
 		Value:    lvl + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(msg, v...))),
-		Path:     "/",
+		Path:     CookiePath(),
 		Expires:  time.Now().Add(1 * time.Minute),
 		HttpOnly: true,
 		Secure:   CookieSecure,


### PR DESCRIPTION
This is in support of https://github.com/arp242/goatcounter/pull/762.

I made `BasePath` work the same as in that PR: leading slash but no trailing slash, so you can just prepend it to other paths. For cookie paths I added a function to use "/" instead of "".